### PR TITLE
Fixing error checking for vmadm create 

### DIFF
--- a/lib/vagrant-smartos/action/run_instance.rb
+++ b/lib/vagrant-smartos/action/run_instance.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_smartos.launching_instance"))
 
           output = env[:hyp].exec("vmadm create <<JSON\n#{JSON.dump(machine_json)}\nJSON")
-          if output.exit_code != 0 || output.stderr.chomp != "Successfully created #{env[:machine].id}"
+          if output.exit_code != 0 || !output.stderr.match("Successfully")
             raise Errors::VmadmError, :message => I18n.t("vagrant_smartos.errors.vmadm_create", :output => output.stderr.chomp)
           end
 

--- a/lib/vagrant-smartos/action/run_instance.rb
+++ b/lib/vagrant-smartos/action/run_instance.rb
@@ -42,6 +42,7 @@ module VagrantPlugins
             "alias" => "vagrant-#{Time.now.to_i}",
             "max_physical_memory" => env[:machine].provider_config.ram,
             "quota" => env[:machine].provider_config.quota,
+            "resolvers" => env[:machine].provider_config.resolvers,
             "nics" => [nic],
             "customer_metadata" => {
               "user-script" => "useradd -s /usr/bin/bash -m vagrant && passwd -N vagrant && mkdir -p ~vagrant/.ssh && echo 'vagrant ALL=NOPASSWD: ALL' >> /opt/local/etc/sudoers && echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' >> ~vagrant/.ssh/authorized_keys"
@@ -50,6 +51,7 @@ module VagrantPlugins
 
           # Launch!
           env[:ui].info(I18n.t("vagrant_smartos.launching_instance"))
+          env[:ui].info("#{JSON.pretty_generate(machine_json)}")
 
           output = env[:hyp].exec("vmadm create <<JSON\n#{JSON.dump(machine_json)}\nJSON")
           if output.exit_code != 0 || !output.stderr.match("Successfully")

--- a/lib/vagrant-smartos/config.rb
+++ b/lib/vagrant-smartos/config.rb
@@ -11,7 +11,14 @@ module VagrantPlugins
       # @return [String] UUID
       attr_accessor :image_uuid
 
-      attr_accessor :resolvers, :nic_tag, :ip_address, :subnet_mask, :gateway, :vlan, :ram, :quota
+      attr_accessor :resolvers
+      attr_accessor :nic_tag
+      attr_accessor :ip_address
+      attr_accessor :subnet_mask
+      attr_accessor :gateway
+      attr_accessor :vlan
+      attr_accessor :ram
+      attr_accessor :quota
 
       def initialize
         @hypervisor = UNSET_VALUE

--- a/lib/vagrant-smartos/config.rb
+++ b/lib/vagrant-smartos/config.rb
@@ -11,11 +11,12 @@ module VagrantPlugins
       # @return [String] UUID
       attr_accessor :image_uuid
 
-      attr_accessor :nic_tag, :ip_address, :subnet_mask, :gateway, :vlan, :ram, :quota
+      attr_accessor :resolvers, :nic_tag, :ip_address, :subnet_mask, :gateway, :vlan, :ram, :quota
 
       def initialize
         @hypervisor = UNSET_VALUE
         @image_uuid = UNSET_VALUE
+	@resolvers = UNSET_VALUE
         @nic_tag = UNSET_VALUE
         @ip_address = UNSET_VALUE
         @subnet_mask = UNSET_VALUE
@@ -29,6 +30,7 @@ module VagrantPlugins
       def finalize!
         @hypervisor = nil if @hypervisor == UNSET_VALUE
         @image_uuid = nil if @image_uuid == UNSET_VALUE
+        @resolvers = ["8.8.8.8", "8.8.4.4"] if @resolvers == UNSET_VALUE
         @nic_tag = "admin" if @nic_tag == UNSET_VALUE
         @ip_address = "dhcp" if @ip_address == UNSET_VALUE
         @subnet_mask = nil if @subnet_mask == UNSET_VALUE


### PR DESCRIPTION
This is somewhat of a duct-tape fix. The success string on my smartos install reads "Successfully created VM [UUID]" and not "Successfully created [UUID]" as is hardcoded into the logic.

I modified the condition to search for "Successfully" in stderr, this should work for both versions.
