### PR TITLE
Prevents creation of VMs on newer SmartOS versions from causing errors

### DIFF
--- a/lib/vagrant-smartos/action/run_instance.rb
+++ b/lib/vagrant-smartos/action/run_instance.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_smartos.launching_instance"))
 
           output = env[:hyp].exec("vmadm create <<JSON\n#{JSON.dump(machine_json)}\nJSON")
-          if output.exit_code != 0 || output.stderr.chomp != "Successfully created #{env[:machine].id}"
+          if output.exit_code != 0 || (output.stderr.chomp =~ /Successfully created( VM)? #{env[:machine].id}/) == nil
             raise Errors::VmadmError, :message => I18n.t("vagrant_smartos.errors.vmadm_create", :output => output.stderr.chomp)
           end
 


### PR DESCRIPTION
The success message has changed in SmartOS from "Successfully created {id}"
to "Successfully created VM {id}". The test has been modified to support
the new message. The old-style messages are still supported.
